### PR TITLE
OPENWIRE-68 - Import OpenWire version 12

### DIFF
--- a/openwire-core/src/main/java/org/apache/activemq/openwire/codec/universal/BrokerSubscriptionInfoMarshaller.java
+++ b/openwire-core/src/main/java/org/apache/activemq/openwire/codec/universal/BrokerSubscriptionInfoMarshaller.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.universal;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.activemq.openwire.codec.*;
+import org.apache.activemq.openwire.commands.*;
+
+/**
+ * Marshalling code for Open Wire for BrokerSubscriptionInfo
+ *
+ * NOTE!: This file is auto generated - do not modify!
+ *
+ */
+public class BrokerSubscriptionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure handled by this Marshaler
+     *
+     * @return short representation of the type data structure
+     */
+    public byte getDataStructureType() {
+        return BrokerSubscriptionInfo.DATA_STRUCTURE_TYPE;
+    }
+    
+    /**
+     * @return a new instance of the managed type.
+     */
+    public DataStructure createObject() {
+        return new BrokerSubscriptionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param wireFormat the OpenWireFormat instance to use
+     * @param target the object to un-marshal
+     * @param dataIn the data input stream to build the object from
+     * @param bs the boolean stream where the type's booleans were marshaled
+     *
+     * @throws IOException if an error occurs while reading the data
+     */
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object target, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, target, dataIn, bs);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo) target;
+
+        info.setBrokerId((BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setBrokerName(tightUnmarshalString(dataIn, bs));
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerInfo value[] = new ConsumerInfo[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (ConsumerInfo) tightUnmarsalNestedObject(wireFormat,dataIn, bs);
+            }
+            info.setSubscriptionInfos(value);
+        } else {
+            info.setSubscriptionInfos(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     *
+     * @param wireFormat the OpenWireFormat instance to use
+     * @param source the object to marshal
+     * @param bs the boolean stream where the type's booleans are written
+     *
+     * @throws IOException if an error occurs while writing the data
+     */
+    public int tightMarshal1(OpenWireFormat wireFormat, Object source, BooleanStream bs) throws IOException {
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo) source;
+
+        int rc = super.tightMarshal1(wireFormat, source, bs);
+        rc += tightMarshalNestedObject1(wireFormat, (DataStructure)info.getBrokerId(), bs);
+        rc += tightMarshalString1(info.getBrokerName(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getSubscriptionInfos(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param wireFormat the OpenWireFormat instance to use
+     * @param source the object to marshal
+     * @param dataOut the DataOut where the properties are written
+     * @param bs the boolean stream where the type's booleans are written
+     *
+     * @throws IOException if an error occurs while writing the data
+     */
+    public void tightMarshal2(OpenWireFormat wireFormat, Object source, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, source, dataOut, bs);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo) source;
+
+        tightMarshalNestedObject2(wireFormat, (DataStructure)info.getBrokerId(), dataOut, bs);
+        tightMarshalString2(info.getBrokerName(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getSubscriptionInfos(), dataOut, bs);
+    }
+
+    /**
+     * Write the object to the output using loose marshaling.
+     *
+     * @throws IOException if an error occurs while writing the data
+     */
+    public void looseMarshal(OpenWireFormat wireFormat, Object source, DataOutput dataOut) throws IOException {
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo) source;
+
+        super.looseMarshal(wireFormat, source, dataOut);
+        looseMarshalNestedObject(wireFormat, (DataStructure)info.getBrokerId(), dataOut);
+        looseMarshalString(info.getBrokerName(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getSubscriptionInfos(), dataOut);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param target the object to un-marshal
+     * @param dataIn the data input stream to build the object from
+     *
+     * @throws IOException if an error occurs while writing the data
+     */
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object target, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, target, dataIn);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo) target;
+
+        info.setBrokerId((BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setBrokerName(looseUnmarshalString(dataIn));
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerInfo value[] = new ConsumerInfo[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (ConsumerInfo) looseUnmarsalNestedObject(wireFormat,dataIn);
+            }
+            info.setSubscriptionInfos(value);
+        } else {
+            info.setSubscriptionInfos(null);
+        }
+    }
+}

--- a/openwire-core/src/main/java/org/apache/activemq/openwire/commands/BrokerSubscriptionInfo.java
+++ b/openwire-core/src/main/java/org/apache/activemq/openwire/commands/BrokerSubscriptionInfo.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.commands;
+
+import org.apache.activemq.openwire.annotations.OpenWireProperty;
+import org.apache.activemq.openwire.annotations.OpenWireType;
+
+/**
+ * Used to represent the durable subscriptions contained by the broker
+ * This is used to synchronize durable subs on bridge creation
+ *
+ * @openwire:marshaller code="92"
+ *
+ */
+@OpenWireType(typeCode = 92)
+public class BrokerSubscriptionInfo extends BaseCommand {
+
+    public static final byte DATA_STRUCTURE_TYPE = CommandTypes.BROKER_SUBSCRIPTION_INFO;
+
+    @OpenWireProperty(version = 1, sequence = 1)
+    BrokerId brokerId;
+
+    @OpenWireProperty(version = 1, sequence = 2)
+    String brokerName;
+
+    @OpenWireProperty(version = 1, sequence = 3)
+    ConsumerInfo subscriptionInfos[];
+
+    public BrokerSubscriptionInfo() {
+
+    }
+
+    public BrokerSubscriptionInfo(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    public BrokerSubscriptionInfo copy() {
+        BrokerSubscriptionInfo copy = new BrokerSubscriptionInfo();
+        copy(copy);
+        return copy;
+    }
+
+    private void copy(BrokerSubscriptionInfo copy) {
+        super.copy(copy);
+        copy.subscriptionInfos = this.subscriptionInfos;
+        copy.brokerName = this.brokerName;
+        copy.brokerId = this.brokerId;
+    }
+
+    @Override
+    public Response visit(CommandVisitor visitor) throws Exception {
+        return visitor.processBrokerSubscriptionInfo(this);
+    }
+
+    @Override
+    public byte getDataStructureType() {
+        return DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @openwire:property version=12
+     */
+    public BrokerId getBrokerId() {
+        return brokerId;
+    }
+
+    public void setBrokerId(BrokerId brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    /**
+     * @openwire:property version=12
+     */
+    public String getBrokerName() {
+        return brokerName;
+    }
+
+    public void setBrokerName(String brokerName) {
+        this.brokerName = brokerName;
+    }
+
+    /**
+     * @openwire:property version=12
+     */
+    public ConsumerInfo[] getSubscriptionInfos() {
+        return subscriptionInfos;
+    }
+
+    public void setSubscriptionInfos(ConsumerInfo[] subscriptionInfos) {
+        this.subscriptionInfos = subscriptionInfos;
+    }
+
+}

--- a/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandTypes.java
+++ b/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandTypes.java
@@ -22,13 +22,16 @@ package org.apache.activemq.openwire.commands;
 public interface CommandTypes {
 
     // What is the latest version of the openwire protocol
-    byte PROTOCOL_VERSION = 11;
+    byte PROTOCOL_VERSION = 12;
 
     // What is the latest version of the openwire protocol used in the stores
     byte PROTOCOL_STORE_VERSION = 11;
 
     // What is the legacy version that old KahaDB store's most commonly used
     byte PROTOCOL_LEGACY_STORE_VERSION = 6;
+
+    // What is the first version that BROKER_SUBSCRIPTION_INFO is supported
+    byte PROTOCOL_VERSION_DURABLE_SYNC = 12;
 
     // A marshaling layer can use this type to specify a null object.
     byte NULL = 0;
@@ -123,6 +126,7 @@ public interface CommandTypes {
 
     byte MESSAGE_DISPATCH_NOTIFICATION = 90;
     byte NETWORK_BRIDGE_FILTER = 91;
+    byte BROKER_SUBSCRIPTION_INFO = 92;
 
     ////////////////////////////////////////////////////////////////////////////
     // Data structures contained in the command objects.

--- a/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandVisitor.java
+++ b/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandVisitor.java
@@ -66,6 +66,8 @@ public interface CommandVisitor {
 
     Response processBrokerInfo(BrokerInfo info) throws Exception;
 
+    Response processBrokerSubscriptionInfo(BrokerSubscriptionInfo info) throws Exception;
+
     Response processRecoverTransactions(TransactionInfo info) throws Exception;
 
     Response processForgetTransaction(TransactionInfo info) throws Exception;

--- a/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandVisitorAdapter.java
+++ b/openwire-core/src/main/java/org/apache/activemq/openwire/commands/CommandVisitorAdapter.java
@@ -54,6 +54,11 @@ public class CommandVisitorAdapter implements CommandVisitor {
     }
 
     @Override
+    public Response processBrokerSubscriptionInfo(BrokerSubscriptionInfo info) throws Exception {
+        return null;
+    }
+
+    @Override
     public Response processCommitTransactionOnePhase(TransactionInfo info) throws Exception {
         return null;
     }

--- a/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/OpenWireInteropTestSupport.java
+++ b/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/OpenWireInteropTestSupport.java
@@ -134,9 +134,15 @@ public abstract class OpenWireInteropTestSupport implements TransportListener {
         command.setCommandId(requestIdGenerator.getAndIncrement());
         command.setResponseRequired(true);
         CountDownLatch complete = new CountDownLatch(1);
-        requestMap.put(new Integer(command.getCommandId()), complete);
+        requestMap.put(command.getCommandId(), complete);
         transport.oneway(command);
         return complete.await(timeout, units);
+    }
+
+    protected void requestNoResponse(Command command) throws Exception {
+        command.setCommandId(requestIdGenerator.getAndIncrement());
+        command.setResponseRequired(false);
+        transport.oneway(command);
     }
 
     protected boolean awaitConnected(long time, TimeUnit unit) throws InterruptedException {

--- a/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/v12/OpenWireV12Test.java
+++ b/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/v12/OpenWireV12Test.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.activemq.broker.TransportConnection;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.openwire.codec.OpenWireInteropTests;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.BrokerSubscriptionInfo;
+import org.apache.activemq.openwire.commands.ConsumerInfo;
+import org.apache.activemq.openwire.utils.OpenWireSession;
+import org.apache.activemq.transport.TransportListener;
+import org.junit.Test;
+
+public class OpenWireV12Test extends OpenWireInteropTests {
+
+    /**
+     * @param tightEncodingEnabled
+     */
+    public OpenWireV12Test(boolean tightEncodingEnabled) {
+        super(tightEncodingEnabled);
+    }
+
+    @Test(timeout = 60000)
+    public void testBrokerSubscriptionInfo() throws Exception {
+        connect();
+        assertTrue(awaitConnected(10, TimeUnit.SECONDS));
+        assertTrue(request(createConnectionInfo(), 10, TimeUnit.SECONDS));
+        assertEquals(1, brokerService.getAdminView().getCurrentConnectionsCount());
+
+        // Should be 1 transport connector and 1 connection
+        assertEquals(1, brokerService.getTransportConnectors().size());
+        TransportConnector connector = brokerService.getTransportConnectors().stream().findFirst().orElseThrow();
+        assertEquals(1, connector.getConnections().size());
+        TransportConnection connection = connector.getConnections().stream().findFirst().orElseThrow();
+
+        // Set a custom transport listener on the broker side to capture the legacy version
+        // of BrokerSubscriptionInfo that we publish with the new marshaller
+        final CountDownLatch received = new CountDownLatch(1);
+        BrokerSubscriptionInfoReceiver receiver = new BrokerSubscriptionInfoReceiver(received);
+        connection.getTransport().setTransportListener(receiver);
+        assertNull(receiver.brokerSubInfo.get());
+
+        // Generate a couple consumer infos
+        OpenWireSession sessionId = connectionId.createOpenWireSession();
+        ConsumerInfo ci1 = new ConsumerInfo(sessionId.getNextConsumerId());
+        ci1.setDispatchAsync(true);
+        ci1.setPrefetchSize(10);
+        ConsumerInfo ci2 = new ConsumerInfo(sessionId.getNextConsumerId());
+        ci2.setDispatchAsync(false);
+        ci2.setPrefetchSize(20);
+
+        // Create BrokerSubscriptionInfo and send using new marshallers
+        BrokerSubscriptionInfo info = new BrokerSubscriptionInfo();
+        info.setBrokerName("testBrokerName");
+        info.setBrokerId(new BrokerId("testBrokerId"));
+        info.setSubscriptionInfos(new ConsumerInfo[]{ ci1, ci2 });
+        requestNoResponse(info);
+        assertTrue(received.await(10, TimeUnit.SECONDS));
+
+        // Verify legacy object converted with legacy marshallers match
+        org.apache.activemq.command.BrokerSubscriptionInfo brokerSubInfo = receiver.brokerSubInfo.get();
+        assertNotNull(brokerSubInfo);
+        assertEquals("testBrokerName", brokerSubInfo.getBrokerName());
+        assertEquals("testBrokerId", brokerSubInfo.getBrokerId().getValue());
+        assertEquals(2, brokerSubInfo.getSubscriptionInfos().length);
+        org.apache.activemq.command.ConsumerInfo legacy1 = brokerSubInfo.getSubscriptionInfos()[0];
+        org.apache.activemq.command.ConsumerInfo legacy2 = brokerSubInfo.getSubscriptionInfos()[1];
+
+        // Verify first consumer info received
+        assertEquals(ci1.getConsumerId().getSessionId(), legacy1.getConsumerId().getSessionId());
+        assertEquals(ci1.getConsumerId().getValue(), legacy1.getConsumerId().getValue());
+        assertEquals(ci1.isDispatchAsync(), legacy1.isDispatchAsync());
+        assertEquals(ci1.getPrefetchSize(), legacy1.getPrefetchSize());
+
+        // Verify second consumer info received
+        assertEquals(ci2.getConsumerId().getSessionId(), legacy2.getConsumerId().getSessionId());
+        assertEquals(ci2.getConsumerId().getValue(), legacy2.getConsumerId().getValue());
+        assertEquals(ci2.isDispatchAsync(), legacy2.isDispatchAsync());
+        assertEquals(ci2.getPrefetchSize(), legacy2.getPrefetchSize());
+    }
+
+    @Override
+    protected int getOpenWireVersion() {
+        return 12;
+    }
+
+    private static class BrokerSubscriptionInfoReceiver implements TransportListener {
+        private final CountDownLatch received;
+        private final AtomicReference<org.apache.activemq.command.BrokerSubscriptionInfo> brokerSubInfo
+            = new AtomicReference<>();
+
+        private BrokerSubscriptionInfoReceiver(CountDownLatch received) {
+            this.received = received;
+        }
+
+        @Override
+        public void onCommand(Object o) {
+            if (o instanceof org.apache.activemq.command.BrokerSubscriptionInfo) {
+                brokerSubInfo.compareAndSet(null,
+                    (org.apache.activemq.command.BrokerSubscriptionInfo) o);
+                received.countDown();
+            }
+        }
+
+        @Override
+        public void onException(IOException e) { }
+
+        @Override
+        public void transportInterupted() { }
+
+        @Override
+        public void transportResumed() { }
+    }
+}

--- a/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/v12/WireFormatInfoV12MarshaledSizeTest.java
+++ b/openwire-interop-tests/src/test/java/org/apache/activemq/openwire/codec/v12/WireFormatInfoV12MarshaledSizeTest.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import org.apache.activemq.openwire.codec.WireFormatInfoMarshaledSizeTest;
+
+/**
+ * Test marshaling with WireFormatInfo for this Version.
+ */
+public class WireFormatInfoV12MarshaledSizeTest extends WireFormatInfoMarshaledSizeTest {
+
+    @Override
+    public int getVersion() {
+        return 12;
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BaseCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BaseCommandMarshaller.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BaseCommand;
+
+public abstract class BaseCommandMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        BaseCommand info = (BaseCommand) o;
+        info.setCommandId(dataIn.readInt());
+        info.setResponseRequired(bs.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        BaseCommand info = (BaseCommand) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        bs.writeBoolean(info.isResponseRequired());
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        BaseCommand info = (BaseCommand) o;
+        dataOut.writeInt(info.getCommandId());
+        bs.readBoolean();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        BaseCommand info = (BaseCommand) o;
+        info.setCommandId(dataIn.readInt());
+        info.setResponseRequired(dataIn.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        BaseCommand info = (BaseCommand) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getCommandId());
+        dataOut.writeBoolean(info.isResponseRequired());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerIdMarshaller.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class BrokerIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return BrokerId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new BrokerId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        BrokerId info = (BrokerId) o;
+        info.setValue(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        BrokerId info = (BrokerId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getValue(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        BrokerId info = (BrokerId) o;
+        tightMarshalString2(info.getValue(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        BrokerId info = (BrokerId) o;
+        info.setValue(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        BrokerId info = (BrokerId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getValue(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerInfoMarshaller.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.BrokerInfo;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class BrokerInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return BrokerInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new BrokerInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        BrokerInfo info = (BrokerInfo) o;
+        info.setBrokerId((BrokerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setBrokerURL(tightUnmarshalString(dataIn, bs));
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerInfo value[] = new BrokerInfo[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerInfo) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setPeerBrokerInfos(value);
+        } else {
+            info.setPeerBrokerInfos(null);
+        }
+        info.setBrokerName(tightUnmarshalString(dataIn, bs));
+        info.setSlaveBroker(bs.readBoolean());
+        info.setMasterBroker(bs.readBoolean());
+        info.setFaultTolerantConfiguration(bs.readBoolean());
+        info.setDuplexConnection(bs.readBoolean());
+        info.setNetworkConnection(bs.readBoolean());
+        info.setConnectionId(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setBrokerUploadUrl(tightUnmarshalString(dataIn, bs));
+        info.setNetworkProperties(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        BrokerInfo info = (BrokerInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getBrokerId(), bs);
+        rc += tightMarshalString1(info.getBrokerURL(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getPeerBrokerInfos(), bs);
+        rc += tightMarshalString1(info.getBrokerName(), bs);
+        bs.writeBoolean(info.isSlaveBroker());
+        bs.writeBoolean(info.isMasterBroker());
+        bs.writeBoolean(info.isFaultTolerantConfiguration());
+        bs.writeBoolean(info.isDuplexConnection());
+        bs.writeBoolean(info.isNetworkConnection());
+        rc += tightMarshalLong1(wireFormat, info.getConnectionId(), bs);
+        rc += tightMarshalString1(info.getBrokerUploadUrl(), bs);
+        rc += tightMarshalString1(info.getNetworkProperties(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        BrokerInfo info = (BrokerInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getBrokerId(), dataOut, bs);
+        tightMarshalString2(info.getBrokerURL(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getPeerBrokerInfos(), dataOut, bs);
+        tightMarshalString2(info.getBrokerName(), dataOut, bs);
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        tightMarshalLong2(wireFormat, info.getConnectionId(), dataOut, bs);
+        tightMarshalString2(info.getBrokerUploadUrl(), dataOut, bs);
+        tightMarshalString2(info.getNetworkProperties(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        BrokerInfo info = (BrokerInfo) o;
+        info.setBrokerId((BrokerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setBrokerURL(looseUnmarshalString(dataIn));
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerInfo value[] = new BrokerInfo[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerInfo) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setPeerBrokerInfos(value);
+        } else {
+            info.setPeerBrokerInfos(null);
+        }
+        info.setBrokerName(looseUnmarshalString(dataIn));
+        info.setSlaveBroker(dataIn.readBoolean());
+        info.setMasterBroker(dataIn.readBoolean());
+        info.setFaultTolerantConfiguration(dataIn.readBoolean());
+        info.setDuplexConnection(dataIn.readBoolean());
+        info.setNetworkConnection(dataIn.readBoolean());
+        info.setConnectionId(looseUnmarshalLong(wireFormat, dataIn));
+        info.setBrokerUploadUrl(looseUnmarshalString(dataIn));
+        info.setNetworkProperties(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        BrokerInfo info = (BrokerInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getBrokerId(), dataOut);
+        looseMarshalString(info.getBrokerURL(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getPeerBrokerInfos(), dataOut);
+        looseMarshalString(info.getBrokerName(), dataOut);
+        dataOut.writeBoolean(info.isSlaveBroker());
+        dataOut.writeBoolean(info.isMasterBroker());
+        dataOut.writeBoolean(info.isFaultTolerantConfiguration());
+        dataOut.writeBoolean(info.isDuplexConnection());
+        dataOut.writeBoolean(info.isNetworkConnection());
+        looseMarshalLong(wireFormat, info.getConnectionId(), dataOut);
+        looseMarshalString(info.getBrokerUploadUrl(), dataOut);
+        looseMarshalString(info.getNetworkProperties(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerSubscriptionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/BrokerSubscriptionInfoMarshaller.java
@@ -1,0 +1,152 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.BrokerSubscriptionInfo;
+import org.apache.activemq.openwire.commands.ConsumerInfo;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class BrokerSubscriptionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     * @return short representation of the type data structure
+     */
+    public byte getDataStructureType() {
+        return BrokerSubscriptionInfo.DATA_STRUCTURE_TYPE;
+    }
+    
+    /**
+     * @return a new object instance
+     */
+    public DataStructure createObject() {
+        return new BrokerSubscriptionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o the object to un-marshal
+     * @param dataIn the data input stream to build the object from
+     * @throws IOException
+     */
+    public void tightUnmarshal(
+        OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo)o;
+        info.setBrokerId((BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setBrokerName(tightUnmarshalString(dataIn, bs));
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerInfo value[] = new ConsumerInfo[size];
+            for( int i=0; i < size; i++ ) {
+                value[i] = (ConsumerInfo) tightUnmarsalNestedObject(wireFormat,dataIn, bs);
+            }
+            info.setSubscriptionInfos(value);
+        }
+        else {
+            info.setSubscriptionInfos(null);
+        }
+
+    }
+
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo)o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getBrokerId(), bs);
+        rc += tightMarshalString1(info.getBrokerName(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getSubscriptionInfos(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o the instance to be marshaled
+     * @param dataOut the output stream
+     * @throws IOException thrown if an error occurs
+     */
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo)o;
+        tightMarshalNestedObject2(wireFormat, info.getBrokerId(), dataOut, bs);
+        tightMarshalString2(info.getBrokerName(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getSubscriptionInfos(), dataOut, bs);
+
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o the object to un-marshal
+     * @param dataIn the data input stream to build the object from
+     * @throws IOException
+     */
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo)o;
+        info.setBrokerId((BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setBrokerName(looseUnmarshalString(dataIn));
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerInfo value[] = new ConsumerInfo[size];
+            for( int i=0; i < size; i++ ) {
+                value[i] = (ConsumerInfo) looseUnmarsalNestedObject(wireFormat,dataIn);
+            }
+            info.setSubscriptionInfos(value);
+        }
+        else {
+            info.setSubscriptionInfos(null);
+        }
+
+    }
+
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+
+        BrokerSubscriptionInfo info = (BrokerSubscriptionInfo)o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getBrokerId(), dataOut);
+        looseMarshalString(info.getBrokerName(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getSubscriptionInfos(), dataOut);
+
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionControlMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionControlMarshaller.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionControl;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ConnectionControlMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConnectionControl.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConnectionControl();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConnectionControl info = (ConnectionControl) o;
+        info.setClose(bs.readBoolean());
+        info.setExit(bs.readBoolean());
+        info.setFaultTolerant(bs.readBoolean());
+        info.setResume(bs.readBoolean());
+        info.setSuspend(bs.readBoolean());
+        info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
+        info.setReconnectTo(tightUnmarshalString(dataIn, bs));
+        info.setRebalanceConnection(bs.readBoolean());
+        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConnectionControl info = (ConnectionControl) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        bs.writeBoolean(info.isClose());
+        bs.writeBoolean(info.isExit());
+        bs.writeBoolean(info.isFaultTolerant());
+        bs.writeBoolean(info.isResume());
+        bs.writeBoolean(info.isSuspend());
+        rc += tightMarshalString1(info.getConnectedBrokers(), bs);
+        rc += tightMarshalString1(info.getReconnectTo(), bs);
+        bs.writeBoolean(info.isRebalanceConnection());
+        rc += tightMarshalByteArray1(info.getToken(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConnectionControl info = (ConnectionControl) o;
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        tightMarshalString2(info.getConnectedBrokers(), dataOut, bs);
+        tightMarshalString2(info.getReconnectTo(), dataOut, bs);
+        bs.readBoolean();
+        tightMarshalByteArray2(info.getToken(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConnectionControl info = (ConnectionControl) o;
+        info.setClose(dataIn.readBoolean());
+        info.setExit(dataIn.readBoolean());
+        info.setFaultTolerant(dataIn.readBoolean());
+        info.setResume(dataIn.readBoolean());
+        info.setSuspend(dataIn.readBoolean());
+        info.setConnectedBrokers(looseUnmarshalString(dataIn));
+        info.setReconnectTo(looseUnmarshalString(dataIn));
+        info.setRebalanceConnection(dataIn.readBoolean());
+        info.setToken(looseUnmarshalByteArray(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConnectionControl info = (ConnectionControl) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeBoolean(info.isClose());
+        dataOut.writeBoolean(info.isExit());
+        dataOut.writeBoolean(info.isFaultTolerant());
+        dataOut.writeBoolean(info.isResume());
+        dataOut.writeBoolean(info.isSuspend());
+        looseMarshalString(info.getConnectedBrokers(), dataOut);
+        looseMarshalString(info.getReconnectTo(), dataOut);
+        dataOut.writeBoolean(info.isRebalanceConnection());
+        looseMarshalByteArray(wireFormat, info.getToken(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionErrorMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionErrorMarshaller.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionError;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ConnectionErrorMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConnectionError.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConnectionError();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConnectionError info = (ConnectionError) o;
+        info.setException(tightUnmarsalThrowable(wireFormat, dataIn, bs));
+        info.setConnectionId((ConnectionId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConnectionError info = (ConnectionError) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalThrowable1(wireFormat, info.getException(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getConnectionId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConnectionError info = (ConnectionError) o;
+        tightMarshalThrowable2(wireFormat, info.getException(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConnectionError info = (ConnectionError) o;
+        info.setException(looseUnmarsalThrowable(wireFormat, dataIn));
+        info.setConnectionId((ConnectionId) looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConnectionError info = (ConnectionError) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalThrowable(wireFormat, info.getException(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getConnectionId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionIdMarshaller.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ConnectionIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConnectionId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConnectionId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConnectionId info = (ConnectionId) o;
+        info.setValue(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConnectionId info = (ConnectionId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getValue(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConnectionId info = (ConnectionId) o;
+        tightMarshalString2(info.getValue(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConnectionId info = (ConnectionId) o;
+        info.setValue(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConnectionId info = (ConnectionId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getValue(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConnectionInfoMarshaller.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.ConnectionInfo;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ConnectionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConnectionInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConnectionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConnectionInfo info = (ConnectionInfo) o;
+        info.setConnectionId((ConnectionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setClientId(tightUnmarshalString(dataIn, bs));
+        info.setPassword(tightUnmarshalString(dataIn, bs));
+        info.setUserName(tightUnmarshalString(dataIn, bs));
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setBrokerMasterConnector(bs.readBoolean());
+        info.setManageable(bs.readBoolean());
+        info.setClientMaster(bs.readBoolean());
+        info.setFaultTolerant(bs.readBoolean());
+        info.setFailoverReconnect(bs.readBoolean());
+        info.setClientIp(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConnectionInfo info = (ConnectionInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConnectionId(), bs);
+        rc += tightMarshalString1(info.getClientId(), bs);
+        rc += tightMarshalString1(info.getPassword(), bs);
+        rc += tightMarshalString1(info.getUserName(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getBrokerPath(), bs);
+        bs.writeBoolean(info.isBrokerMasterConnector());
+        bs.writeBoolean(info.isManageable());
+        bs.writeBoolean(info.isClientMaster());
+        bs.writeBoolean(info.isFaultTolerant());
+        bs.writeBoolean(info.isFailoverReconnect());
+        rc += tightMarshalString1(info.getClientIp(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConnectionInfo info = (ConnectionInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+        tightMarshalString2(info.getClientId(), dataOut, bs);
+        tightMarshalString2(info.getPassword(), dataOut, bs);
+        tightMarshalString2(info.getUserName(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getBrokerPath(), dataOut, bs);
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        tightMarshalString2(info.getClientIp(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConnectionInfo info = (ConnectionInfo) o;
+        info.setConnectionId((ConnectionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setClientId(looseUnmarshalString(dataIn));
+        info.setPassword(looseUnmarshalString(dataIn));
+        info.setUserName(looseUnmarshalString(dataIn));
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setBrokerMasterConnector(dataIn.readBoolean());
+        info.setManageable(dataIn.readBoolean());
+        info.setClientMaster(dataIn.readBoolean());
+        info.setFaultTolerant(dataIn.readBoolean());
+        info.setFailoverReconnect(dataIn.readBoolean());
+        info.setClientIp(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConnectionInfo info = (ConnectionInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConnectionId(), dataOut);
+        looseMarshalString(info.getClientId(), dataOut);
+        looseMarshalString(info.getPassword(), dataOut);
+        looseMarshalString(info.getUserName(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getBrokerPath(), dataOut);
+        dataOut.writeBoolean(info.isBrokerMasterConnector());
+        dataOut.writeBoolean(info.isManageable());
+        dataOut.writeBoolean(info.isClientMaster());
+        dataOut.writeBoolean(info.isFaultTolerant());
+        dataOut.writeBoolean(info.isFailoverReconnect());
+        looseMarshalString(info.getClientIp(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerControlMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerControlMarshaller.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerControl;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class ConsumerControlMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConsumerControl.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConsumerControl();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConsumerControl info = (ConsumerControl) o;
+        info.setDestination((OpenWireDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setClose(bs.readBoolean());
+        info.setConsumerId((ConsumerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setPrefetch(dataIn.readInt());
+        info.setFlush(bs.readBoolean());
+        info.setStart(bs.readBoolean());
+        info.setStop(bs.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConsumerControl info = (ConsumerControl) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getDestination(), bs);
+        bs.writeBoolean(info.isClose());
+        rc += tightMarshalNestedObject1(wireFormat, info.getConsumerId(), bs);
+        bs.writeBoolean(info.isFlush());
+        bs.writeBoolean(info.isStart());
+        bs.writeBoolean(info.isStop());
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConsumerControl info = (ConsumerControl) o;
+        tightMarshalNestedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        bs.readBoolean();
+        tightMarshalNestedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        dataOut.writeInt(info.getPrefetch());
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConsumerControl info = (ConsumerControl) o;
+        info.setDestination((OpenWireDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setClose(dataIn.readBoolean());
+        info.setConsumerId((ConsumerId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setPrefetch(dataIn.readInt());
+        info.setFlush(dataIn.readBoolean());
+        info.setStart(dataIn.readBoolean());
+        info.setStop(dataIn.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConsumerControl info = (ConsumerControl) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getDestination(), dataOut);
+        dataOut.writeBoolean(info.isClose());
+        looseMarshalNestedObject(wireFormat, info.getConsumerId(), dataOut);
+        dataOut.writeInt(info.getPrefetch());
+        dataOut.writeBoolean(info.isFlush());
+        dataOut.writeBoolean(info.isStart());
+        dataOut.writeBoolean(info.isStop());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerIdMarshaller.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ConsumerIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConsumerId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConsumerId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConsumerId info = (ConsumerId) o;
+        info.setConnectionId(tightUnmarshalString(dataIn, bs));
+        info.setSessionId(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setValue(tightUnmarshalLong(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConsumerId info = (ConsumerId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getConnectionId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getSessionId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getValue(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConsumerId info = (ConsumerId) o;
+        tightMarshalString2(info.getConnectionId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getSessionId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getValue(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConsumerId info = (ConsumerId) o;
+        info.setConnectionId(looseUnmarshalString(dataIn));
+        info.setSessionId(looseUnmarshalLong(wireFormat, dataIn));
+        info.setValue(looseUnmarshalLong(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConsumerId info = (ConsumerId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getConnectionId(), dataOut);
+        looseMarshalLong(wireFormat, info.getSessionId(), dataOut);
+        looseMarshalLong(wireFormat, info.getValue(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ConsumerInfoMarshaller.java
@@ -1,0 +1,252 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.ConsumerInfo;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class ConsumerInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ConsumerInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ConsumerInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ConsumerInfo info = (ConsumerInfo) o;
+        info.setConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setBrowser(bs.readBoolean());
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setPrefetchSize(dataIn.readInt());
+        info.setMaximumPendingMessageLimit(dataIn.readInt());
+        info.setDispatchAsync(bs.readBoolean());
+        info.setSelector(tightUnmarshalString(dataIn, bs));
+        info.setClientId(tightUnmarshalString(dataIn, bs));
+        info.setSubscriptionName(tightUnmarshalString(dataIn, bs));
+        info.setNoLocal(bs.readBoolean());
+        info.setExclusive(bs.readBoolean());
+        info.setRetroactive(bs.readBoolean());
+        info.setPriority(dataIn.readByte());
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setAdditionalPredicate(tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setNetworkSubscription(bs.readBoolean());
+        info.setOptimizedAcknowledge(bs.readBoolean());
+        info.setNoRangeAcks(bs.readBoolean());
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerId value[] = new ConsumerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (ConsumerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setNetworkConsumerPath(value);
+        } else {
+            info.setNetworkConsumerPath(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ConsumerInfo info = (ConsumerInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConsumerId(), bs);
+        bs.writeBoolean(info.isBrowser());
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        bs.writeBoolean(info.isDispatchAsync());
+        rc += tightMarshalString1(info.getSelector(), bs);
+        rc += tightMarshalString1(info.getClientId(), bs);
+        rc += tightMarshalString1(info.getSubscriptionName(), bs);
+        bs.writeBoolean(info.isNoLocal());
+        bs.writeBoolean(info.isExclusive());
+        bs.writeBoolean(info.isRetroactive());
+        rc += tightMarshalObjectArray1(wireFormat, info.getBrokerPath(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, (DataStructure) info.getAdditionalPredicate(), bs);
+        bs.writeBoolean(info.isNetworkSubscription());
+        bs.writeBoolean(info.isOptimizedAcknowledge());
+        bs.writeBoolean(info.isNoRangeAcks());
+        rc += tightMarshalObjectArray1(wireFormat, info.getNetworkConsumerPath(), bs);
+
+        return rc + 9;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ConsumerInfo info = (ConsumerInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        bs.readBoolean();
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        dataOut.writeInt(info.getPrefetchSize());
+        dataOut.writeInt(info.getMaximumPendingMessageLimit());
+        bs.readBoolean();
+        tightMarshalString2(info.getSelector(), dataOut, bs);
+        tightMarshalString2(info.getClientId(), dataOut, bs);
+        tightMarshalString2(info.getSubscriptionName(), dataOut, bs);
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        dataOut.writeByte(info.getPriority());
+        tightMarshalObjectArray2(wireFormat, info.getBrokerPath(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, (DataStructure) info.getAdditionalPredicate(), dataOut, bs);
+        bs.readBoolean();
+        bs.readBoolean();
+        bs.readBoolean();
+        tightMarshalObjectArray2(wireFormat, info.getNetworkConsumerPath(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ConsumerInfo info = (ConsumerInfo) o;
+        info.setConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setBrowser(dataIn.readBoolean());
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setPrefetchSize(dataIn.readInt());
+        info.setMaximumPendingMessageLimit(dataIn.readInt());
+        info.setDispatchAsync(dataIn.readBoolean());
+        info.setSelector(looseUnmarshalString(dataIn));
+        info.setClientId(looseUnmarshalString(dataIn));
+        info.setSubscriptionName(looseUnmarshalString(dataIn));
+        info.setNoLocal(dataIn.readBoolean());
+        info.setExclusive(dataIn.readBoolean());
+        info.setRetroactive(dataIn.readBoolean());
+        info.setPriority(dataIn.readByte());
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setAdditionalPredicate(looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setNetworkSubscription(dataIn.readBoolean());
+        info.setOptimizedAcknowledge(dataIn.readBoolean());
+        info.setNoRangeAcks(dataIn.readBoolean());
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            ConsumerId value[] = new ConsumerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (ConsumerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setNetworkConsumerPath(value);
+        } else {
+            info.setNetworkConsumerPath(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ConsumerInfo info = (ConsumerInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConsumerId(), dataOut);
+        dataOut.writeBoolean(info.isBrowser());
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        dataOut.writeInt(info.getPrefetchSize());
+        dataOut.writeInt(info.getMaximumPendingMessageLimit());
+        dataOut.writeBoolean(info.isDispatchAsync());
+        looseMarshalString(info.getSelector(), dataOut);
+        looseMarshalString(info.getClientId(), dataOut);
+        looseMarshalString(info.getSubscriptionName(), dataOut);
+        dataOut.writeBoolean(info.isNoLocal());
+        dataOut.writeBoolean(info.isExclusive());
+        dataOut.writeBoolean(info.isRetroactive());
+        dataOut.writeByte(info.getPriority());
+        looseMarshalObjectArray(wireFormat, info.getBrokerPath(), dataOut);
+        looseMarshalNestedObject(wireFormat, (DataStructure) info.getAdditionalPredicate(), dataOut);
+        dataOut.writeBoolean(info.isNetworkSubscription());
+        dataOut.writeBoolean(info.isOptimizedAcknowledge());
+        dataOut.writeBoolean(info.isNoRangeAcks());
+        looseMarshalObjectArray(wireFormat, info.getNetworkConsumerPath(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ControlCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ControlCommandMarshaller.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ControlCommand;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class ControlCommandMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ControlCommand.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ControlCommand();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ControlCommand info = (ControlCommand) o;
+        info.setCommand(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ControlCommand info = (ControlCommand) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getCommand(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ControlCommand info = (ControlCommand) o;
+        tightMarshalString2(info.getCommand(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ControlCommand info = (ControlCommand) o;
+        info.setCommand(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ControlCommand info = (ControlCommand) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getCommand(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DataArrayResponseMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DataArrayResponseMarshaller.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataArrayResponse;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class DataArrayResponseMarshaller extends ResponseMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return DataArrayResponse.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new DataArrayResponse();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        DataArrayResponse info = (DataArrayResponse) o;
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            DataStructure value[] = new DataStructure[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setData(value);
+        } else {
+            info.setData(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        DataArrayResponse info = (DataArrayResponse) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getData(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        DataArrayResponse info = (DataArrayResponse) o;
+        tightMarshalObjectArray2(wireFormat, info.getData(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        DataArrayResponse info = (DataArrayResponse) o;
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            DataStructure value[] = new DataStructure[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setData(value);
+        } else {
+            info.setData(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+
+        DataArrayResponse info = (DataArrayResponse) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalObjectArray(wireFormat, info.getData(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DataResponseMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DataResponseMarshaller.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataResponse;
+import org.apache.activemq.openwire.commands.DataStructure;
+
+public class DataResponseMarshaller extends ResponseMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return DataResponse.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new DataResponse();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        DataResponse info = (DataResponse) o;
+        info.setData(tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        DataResponse info = (DataResponse) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getData(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        DataResponse info = (DataResponse) o;
+        tightMarshalNestedObject2(wireFormat, info.getData(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        DataResponse info = (DataResponse) o;
+        info.setData(looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        DataResponse info = (DataResponse) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getData(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DestinationInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DestinationInfoMarshaller.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.DestinationInfo;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class DestinationInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return DestinationInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new DestinationInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        DestinationInfo info = (DestinationInfo) o;
+        info.setConnectionId((ConnectionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setOperationType(dataIn.readByte());
+        info.setTimeout(tightUnmarshalLong(wireFormat, dataIn, bs));
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        DestinationInfo info = (DestinationInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConnectionId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getTimeout(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getBrokerPath(), bs);
+
+        return rc + 1;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        DestinationInfo info = (DestinationInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        dataOut.writeByte(info.getOperationType());
+        tightMarshalLong2(wireFormat, info.getTimeout(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getBrokerPath(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        DestinationInfo info = (DestinationInfo) o;
+        info.setConnectionId((ConnectionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setOperationType(dataIn.readByte());
+        info.setTimeout(looseUnmarshalLong(wireFormat, dataIn));
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        DestinationInfo info = (DestinationInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConnectionId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        dataOut.writeByte(info.getOperationType());
+        looseMarshalLong(wireFormat, info.getTimeout(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getBrokerPath(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DiscoveryEventMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/DiscoveryEventMarshaller.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.DiscoveryEvent;
+
+public class DiscoveryEventMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return DiscoveryEvent.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new DiscoveryEvent();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        DiscoveryEvent info = (DiscoveryEvent) o;
+        info.setServiceName(tightUnmarshalString(dataIn, bs));
+        info.setBrokerName(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        DiscoveryEvent info = (DiscoveryEvent) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getServiceName(), bs);
+        rc += tightMarshalString1(info.getBrokerName(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        DiscoveryEvent info = (DiscoveryEvent) o;
+        tightMarshalString2(info.getServiceName(), dataOut, bs);
+        tightMarshalString2(info.getBrokerName(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        DiscoveryEvent info = (DiscoveryEvent) o;
+        info.setServiceName(looseUnmarshalString(dataIn));
+        info.setBrokerName(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        DiscoveryEvent info = (DiscoveryEvent) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getServiceName(), dataOut);
+        looseMarshalString(info.getBrokerName(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ExceptionResponseMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ExceptionResponseMarshaller.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.ExceptionResponse;
+
+public class ExceptionResponseMarshaller extends ResponseMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ExceptionResponse.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ExceptionResponse();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ExceptionResponse info = (ExceptionResponse) o;
+        info.setException(tightUnmarsalThrowable(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ExceptionResponse info = (ExceptionResponse) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalThrowable1(wireFormat, info.getException(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ExceptionResponse info = (ExceptionResponse) o;
+        tightMarshalThrowable2(wireFormat, info.getException(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ExceptionResponse info = (ExceptionResponse) o;
+        info.setException(looseUnmarsalThrowable(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ExceptionResponse info = (ExceptionResponse) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalThrowable(wireFormat, info.getException(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/FlushCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/FlushCommandMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.FlushCommand;
+
+public class FlushCommandMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return FlushCommand.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new FlushCommand();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/IntegerResponseMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/IntegerResponseMarshaller.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.IntegerResponse;
+
+public class IntegerResponseMarshaller extends ResponseMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return IntegerResponse.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new IntegerResponse();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        IntegerResponse info = (IntegerResponse) o;
+        info.setResult(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        IntegerResponse info = (IntegerResponse) o;
+        dataOut.writeInt(info.getResult());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        IntegerResponse info = (IntegerResponse) o;
+        info.setResult(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        IntegerResponse info = (IntegerResponse) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getResult());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalQueueAckMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalQueueAckMarshaller.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.JournalQueueAck;
+import org.apache.activemq.openwire.commands.MessageAck;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class JournalQueueAckMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return JournalQueueAck.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new JournalQueueAck();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        JournalQueueAck info = (JournalQueueAck) o;
+        info.setDestination((OpenWireDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setMessageAck((MessageAck) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        JournalQueueAck info = (JournalQueueAck) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessageAck(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        JournalQueueAck info = (JournalQueueAck) o;
+        tightMarshalNestedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessageAck(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        JournalQueueAck info = (JournalQueueAck) o;
+        info.setDestination((OpenWireDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setMessageAck((MessageAck) looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        JournalQueueAck info = (JournalQueueAck) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessageAck(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTopicAckMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTopicAckMarshaller.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.JournalTopicAck;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+import org.apache.activemq.openwire.commands.TransactionId;
+
+public class JournalTopicAckMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return JournalTopicAck.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new JournalTopicAck();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        JournalTopicAck info = (JournalTopicAck) o;
+        info.setDestination((OpenWireDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setMessageSequenceId(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setSubscritionName(tightUnmarshalString(dataIn, bs));
+        info.setClientId(tightUnmarshalString(dataIn, bs));
+        info.setTransactionId((TransactionId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        JournalTopicAck info = (JournalTopicAck) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessageId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getMessageSequenceId(), bs);
+        rc += tightMarshalString1(info.getSubscritionName(), bs);
+        rc += tightMarshalString1(info.getClientId(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getTransactionId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        JournalTopicAck info = (JournalTopicAck) o;
+        tightMarshalNestedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessageId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getMessageSequenceId(), dataOut, bs);
+        tightMarshalString2(info.getSubscritionName(), dataOut, bs);
+        tightMarshalString2(info.getClientId(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getTransactionId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        JournalTopicAck info = (JournalTopicAck) o;
+        info.setDestination((OpenWireDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setMessageSequenceId(looseUnmarshalLong(wireFormat, dataIn));
+        info.setSubscritionName(looseUnmarshalString(dataIn));
+        info.setClientId(looseUnmarshalString(dataIn));
+        info.setTransactionId((TransactionId) looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        JournalTopicAck info = (JournalTopicAck) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessageId(), dataOut);
+        looseMarshalLong(wireFormat, info.getMessageSequenceId(), dataOut);
+        looseMarshalString(info.getSubscritionName(), dataOut);
+        looseMarshalString(info.getClientId(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getTransactionId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTraceMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTraceMarshaller.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.JournalTrace;
+
+public class JournalTraceMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return JournalTrace.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new JournalTrace();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        JournalTrace info = (JournalTrace) o;
+        info.setMessage(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        JournalTrace info = (JournalTrace) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getMessage(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        JournalTrace info = (JournalTrace) o;
+        tightMarshalString2(info.getMessage(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        JournalTrace info = (JournalTrace) o;
+        info.setMessage(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        JournalTrace info = (JournalTrace) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getMessage(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTransactionMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/JournalTransactionMarshaller.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.JournalTransaction;
+import org.apache.activemq.openwire.commands.TransactionId;
+
+public class JournalTransactionMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return JournalTransaction.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new JournalTransaction();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        JournalTransaction info = (JournalTransaction) o;
+        info.setTransactionId((TransactionId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setType(dataIn.readByte());
+        info.setWasPrepared(bs.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        JournalTransaction info = (JournalTransaction) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getTransactionId(), bs);
+        bs.writeBoolean(info.getWasPrepared());
+
+        return rc + 1;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        JournalTransaction info = (JournalTransaction) o;
+        tightMarshalNestedObject2(wireFormat, info.getTransactionId(), dataOut, bs);
+        dataOut.writeByte(info.getType());
+        bs.readBoolean();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        JournalTransaction info = (JournalTransaction) o;
+        info.setTransactionId((TransactionId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setType(dataIn.readByte());
+        info.setWasPrepared(dataIn.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        JournalTransaction info = (JournalTransaction) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getTransactionId(), dataOut);
+        dataOut.writeByte(info.getType());
+        dataOut.writeBoolean(info.getWasPrepared());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/KeepAliveInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/KeepAliveInfoMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.KeepAliveInfo;
+
+public class KeepAliveInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return KeepAliveInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new KeepAliveInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/LastPartialCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/LastPartialCommandMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.LastPartialCommand;
+
+public class LastPartialCommandMarshaller extends PartialCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return LastPartialCommand.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new LastPartialCommand();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/LocalTransactionIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/LocalTransactionIdMarshaller.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.LocalTransactionId;
+
+public class LocalTransactionIdMarshaller extends TransactionIdMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return LocalTransactionId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new LocalTransactionId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        LocalTransactionId info = (LocalTransactionId) o;
+        info.setValue(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setConnectionId((ConnectionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        LocalTransactionId info = (LocalTransactionId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalLong1(wireFormat, info.getValue(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConnectionId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        LocalTransactionId info = (LocalTransactionId) o;
+        tightMarshalLong2(wireFormat, info.getValue(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        LocalTransactionId info = (LocalTransactionId) o;
+        info.setValue(looseUnmarshalLong(wireFormat, dataIn));
+        info.setConnectionId((ConnectionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        LocalTransactionId info = (LocalTransactionId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalLong(wireFormat, info.getValue(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConnectionId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MarshallerFactory.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MarshallerFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,18 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.openwire.codec.universal;
+package org.apache.activemq.openwire.codec.v12;
 
 import org.apache.activemq.openwire.codec.DataStreamMarshaller;
 import org.apache.activemq.openwire.codec.OpenWireFormat;
 
-/**
- * Marshalling Factory for the Universal OpenWire Codec package.
- *
- * NOTE!: This file is auto generated - do not modify!
- *
- */
-public class MarshallerFactory{
+public class MarshallerFactory {
 
     /**
      * Creates a Map of command type -> Marshallers
@@ -33,6 +27,17 @@ public class MarshallerFactory{
     static final private DataStreamMarshaller marshaller[] = new DataStreamMarshaller[256];
     static {
 
+        add(new OpenWireBlobMessageMarshaller());
+        add(new OpenWireBytesMessageMarshaller());
+        add(new OpenWireMapMessageMarshaller());
+        add(new OpenWireMessageMarshaller());
+        add(new OpenWireObjectMessageMarshaller());
+        add(new OpenWireQueueMarshaller());
+        add(new OpenWireStreamMessageMarshaller());
+        add(new OpenWireTempQueueMarshaller());
+        add(new OpenWireTempTopicMarshaller());
+        add(new OpenWireTextMessageMarshaller());
+        add(new OpenWireTopicMarshaller());
         add(new BrokerIdMarshaller());
         add(new BrokerInfoMarshaller());
         add(new BrokerSubscriptionInfoMarshaller());
@@ -64,17 +69,6 @@ public class MarshallerFactory{
         add(new MessageIdMarshaller());
         add(new MessagePullMarshaller());
         add(new NetworkBridgeFilterMarshaller());
-        add(new OpenWireBlobMessageMarshaller());
-        add(new OpenWireBytesMessageMarshaller());
-        add(new OpenWireMapMessageMarshaller());
-        add(new OpenWireMessageMarshaller());
-        add(new OpenWireObjectMessageMarshaller());
-        add(new OpenWireQueueMarshaller());
-        add(new OpenWireStreamMessageMarshaller());
-        add(new OpenWireTempQueueMarshaller());
-        add(new OpenWireTempTopicMarshaller());
-        add(new OpenWireTextMessageMarshaller());
-        add(new OpenWireTopicMarshaller());
         add(new PartialCommandMarshaller());
         add(new ProducerAckMarshaller());
         add(new ProducerIdMarshaller());

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageAckMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageAckMarshaller.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.MessageAck;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+import org.apache.activemq.openwire.commands.TransactionId;
+
+public class MessageAckMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     * 
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return MessageAck.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new MessageAck();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     * 
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        MessageAck info = (MessageAck) o;
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setTransactionId((TransactionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setAckType(dataIn.readByte());
+        info.setFirstMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setLastMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setMessageCount(dataIn.readInt());
+        info.setPoisonCause(tightUnmarsalThrowable(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        MessageAck info = (MessageAck) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getTransactionId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConsumerId(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getFirstMessageId(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getLastMessageId(), bs);
+        rc += tightMarshalThrowable1(wireFormat, info.getPoisonCause(), bs);
+
+        return rc + 5;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     * 
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        MessageAck info = (MessageAck) o;
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getTransactionId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        dataOut.writeByte(info.getAckType());
+        tightMarshalNestedObject2(wireFormat, info.getFirstMessageId(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getLastMessageId(), dataOut, bs);
+        dataOut.writeInt(info.getMessageCount());
+        tightMarshalThrowable2(wireFormat, info.getPoisonCause(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     * 
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        MessageAck info = (MessageAck) o;
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setTransactionId((TransactionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setAckType(dataIn.readByte());
+        info.setFirstMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setLastMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setMessageCount(dataIn.readInt());
+        info.setPoisonCause(looseUnmarsalThrowable(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        MessageAck info = (MessageAck) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getTransactionId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConsumerId(), dataOut);
+        dataOut.writeByte(info.getAckType());
+        looseMarshalNestedObject(wireFormat, info.getFirstMessageId(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getLastMessageId(), dataOut);
+        dataOut.writeInt(info.getMessageCount());
+        looseMarshalThrowable(wireFormat, info.getPoisonCause(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageDispatchMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageDispatchMarshaller.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.Message;
+import org.apache.activemq.openwire.commands.MessageDispatch;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class MessageDispatchMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return MessageDispatch.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new MessageDispatch();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        MessageDispatch info = (MessageDispatch) o;
+        info.setConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setMessage((Message) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setRedeliveryCounter(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        MessageDispatch info = (MessageDispatch) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConsumerId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessage(), bs);
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        MessageDispatch info = (MessageDispatch) o;
+        tightMarshalCachedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessage(), dataOut, bs);
+        dataOut.writeInt(info.getRedeliveryCounter());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        MessageDispatch info = (MessageDispatch) o;
+        info.setConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setMessage((Message) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setRedeliveryCounter(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        MessageDispatch info = (MessageDispatch) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConsumerId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessage(), dataOut);
+        dataOut.writeInt(info.getRedeliveryCounter());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageDispatchNotificationMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageDispatchNotificationMarshaller.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.MessageDispatchNotification;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class MessageDispatchNotificationMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return MessageDispatchNotification.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new MessageDispatchNotification();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        MessageDispatchNotification info = (MessageDispatchNotification) o;
+        info.setConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDeliverySequenceId(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        MessageDispatchNotification info = (MessageDispatchNotification) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConsumerId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getDeliverySequenceId(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessageId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        MessageDispatchNotification info = (MessageDispatchNotification) o;
+        tightMarshalCachedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getDeliverySequenceId(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessageId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        MessageDispatchNotification info = (MessageDispatchNotification) o;
+        info.setConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDeliverySequenceId(looseUnmarshalLong(wireFormat, dataIn));
+        info.setMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        MessageDispatchNotification info = (MessageDispatchNotification) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConsumerId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalLong(wireFormat, info.getDeliverySequenceId(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessageId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageIdMarshaller.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.ProducerId;
+
+public class MessageIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return MessageId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new MessageId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        MessageId info = (MessageId) o;
+        info.setTextView(tightUnmarshalString(dataIn, bs));
+        info.setProducerId((ProducerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setProducerSequenceId(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setBrokerSequenceId(tightUnmarshalLong(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        MessageId info = (MessageId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getTextView(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getProducerId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getProducerSequenceId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getBrokerSequenceId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        MessageId info = (MessageId) o;
+        tightMarshalString2(info.getTextView(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getProducerId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getProducerSequenceId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getBrokerSequenceId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        MessageId info = (MessageId) o;
+        info.setTextView(looseUnmarshalString(dataIn));
+        info.setProducerId((ProducerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setProducerSequenceId(looseUnmarshalLong(wireFormat, dataIn));
+        info.setBrokerSequenceId(looseUnmarshalLong(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        MessageId info = (MessageId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getTextView(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getProducerId(), dataOut);
+        looseMarshalLong(wireFormat, info.getProducerSequenceId(), dataOut);
+        looseMarshalLong(wireFormat, info.getBrokerSequenceId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessageMarshaller.java
@@ -1,0 +1,308 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.Message;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+import org.apache.activemq.openwire.commands.ProducerId;
+import org.apache.activemq.openwire.commands.TransactionId;
+
+public abstract class MessageMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        Message info = (Message) o;
+
+        info.beforeUnmarshall(wireFormat);
+
+        info.setProducerId((ProducerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setTransactionId((TransactionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setOriginalDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setOriginalTransactionId((TransactionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setGroupID(tightUnmarshalString(dataIn, bs));
+        info.setGroupSequence(dataIn.readInt());
+        info.setCorrelationId(tightUnmarshalString(dataIn, bs));
+        info.setPersistent(bs.readBoolean());
+        info.setExpiration(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setPriority(dataIn.readByte());
+        info.setReplyTo((OpenWireDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setType(tightUnmarshalString(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setDataStructure(tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setTargetConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setCompressed(bs.readBoolean());
+        info.setRedeliveryCounter(dataIn.readInt());
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setArrival(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setUserId(tightUnmarshalString(dataIn, bs));
+        info.setRecievedByDFBridge(bs.readBoolean());
+        info.setDroppable(bs.readBoolean());
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setCluster(value);
+        } else {
+            info.setCluster(null);
+        }
+        info.setBrokerInTime(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setBrokerOutTime(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setJMSXGroupFirstForConsumer(bs.readBoolean());
+
+        info.afterUnmarshall(wireFormat);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+
+        Message info = (Message) o;
+
+        info.beforeMarshall(wireFormat);
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getProducerId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getTransactionId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getOriginalDestination(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessageId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getOriginalTransactionId(), bs);
+        rc += tightMarshalString1(info.getGroupId(), bs);
+        rc += tightMarshalString1(info.getCorrelationId(), bs);
+        bs.writeBoolean(info.isPersistent());
+        rc += tightMarshalLong1(wireFormat, info.getExpiration(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getReplyTo(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getTimestamp(), bs);
+        rc += tightMarshalString1(info.getType(), bs);
+        rc += tightMarshalByteSequence1(info.getContent(), bs);
+        rc += tightMarshalByteSequence1(info.getMarshalledProperties(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getDataStructure(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getTargetConsumerId(), bs);
+        bs.writeBoolean(info.isCompressed());
+        rc += tightMarshalObjectArray1(wireFormat, info.getBrokerPath(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getArrival(), bs);
+        rc += tightMarshalString1(info.getUserId(), bs);
+        bs.writeBoolean(info.isRecievedByDFBridge());
+        bs.writeBoolean(info.isDroppable());
+        rc += tightMarshalObjectArray1(wireFormat, info.getCluster(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getBrokerInTime(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getBrokerOutTime(), bs);
+        bs.writeBoolean(info.isJMSXGroupFirstForConsumer());
+
+        return rc + 9;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        Message info = (Message) o;
+        tightMarshalCachedObject2(wireFormat, info.getProducerId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getTransactionId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getOriginalDestination(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessageId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getOriginalTransactionId(), dataOut, bs);
+        tightMarshalString2(info.getGroupId(), dataOut, bs);
+        dataOut.writeInt(info.getGroupSequence());
+        tightMarshalString2(info.getCorrelationId(), dataOut, bs);
+        bs.readBoolean();
+        tightMarshalLong2(wireFormat, info.getExpiration(), dataOut, bs);
+        dataOut.writeByte(info.getPriority());
+        tightMarshalNestedObject2(wireFormat, info.getReplyTo(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getTimestamp(), dataOut, bs);
+        tightMarshalString2(info.getType(), dataOut, bs);
+        tightMarshalByteSequence2(info.getContent(), dataOut, bs);
+        tightMarshalByteSequence2(info.getMarshalledProperties(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getDataStructure(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getTargetConsumerId(), dataOut, bs);
+        bs.readBoolean();
+        dataOut.writeInt(info.getRedeliveryCounter());
+        tightMarshalObjectArray2(wireFormat, info.getBrokerPath(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getArrival(), dataOut, bs);
+        tightMarshalString2(info.getUserId(), dataOut, bs);
+        bs.readBoolean();
+        bs.readBoolean();
+        tightMarshalObjectArray2(wireFormat, info.getCluster(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getBrokerInTime(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getBrokerOutTime(), dataOut, bs);
+        bs.readBoolean();
+
+        info.afterMarshall(wireFormat);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        Message info = (Message) o;
+
+        info.beforeUnmarshall(wireFormat);
+
+        info.setProducerId((ProducerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setTransactionId((TransactionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setOriginalDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setOriginalTransactionId((TransactionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setGroupID(looseUnmarshalString(dataIn));
+        info.setGroupSequence(dataIn.readInt());
+        info.setCorrelationId(looseUnmarshalString(dataIn));
+        info.setPersistent(dataIn.readBoolean());
+        info.setExpiration(looseUnmarshalLong(wireFormat, dataIn));
+        info.setPriority(dataIn.readByte());
+        info.setReplyTo((OpenWireDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
+        info.setType(looseUnmarshalString(dataIn));
+        info.setContent(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setDataStructure(looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setTargetConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setCompressed(dataIn.readBoolean());
+        info.setRedeliveryCounter(dataIn.readInt());
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setArrival(looseUnmarshalLong(wireFormat, dataIn));
+        info.setUserId(looseUnmarshalString(dataIn));
+        info.setRecievedByDFBridge(dataIn.readBoolean());
+        info.setDroppable(dataIn.readBoolean());
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setCluster(value);
+        } else {
+            info.setCluster(null);
+        }
+        info.setBrokerInTime(looseUnmarshalLong(wireFormat, dataIn));
+        info.setBrokerOutTime(looseUnmarshalLong(wireFormat, dataIn));
+        info.setJMSXGroupFirstForConsumer(dataIn.readBoolean());
+
+        info.afterUnmarshall(wireFormat);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        Message info = (Message) o;
+
+        info.beforeMarshall(wireFormat);
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getProducerId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getTransactionId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getOriginalDestination(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessageId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getOriginalTransactionId(), dataOut);
+        looseMarshalString(info.getGroupId(), dataOut);
+        dataOut.writeInt(info.getGroupSequence());
+        looseMarshalString(info.getCorrelationId(), dataOut);
+        dataOut.writeBoolean(info.isPersistent());
+        looseMarshalLong(wireFormat, info.getExpiration(), dataOut);
+        dataOut.writeByte(info.getPriority());
+        looseMarshalNestedObject(wireFormat, info.getReplyTo(), dataOut);
+        looseMarshalLong(wireFormat, info.getTimestamp(), dataOut);
+        looseMarshalString(info.getType(), dataOut);
+        looseMarshalByteSequence(wireFormat, info.getContent(), dataOut);
+        looseMarshalByteSequence(wireFormat, info.getMarshalledProperties(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getDataStructure(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getTargetConsumerId(), dataOut);
+        dataOut.writeBoolean(info.isCompressed());
+        dataOut.writeInt(info.getRedeliveryCounter());
+        looseMarshalObjectArray(wireFormat, info.getBrokerPath(), dataOut);
+        looseMarshalLong(wireFormat, info.getArrival(), dataOut);
+        looseMarshalString(info.getUserId(), dataOut);
+        dataOut.writeBoolean(info.isRecievedByDFBridge());
+        dataOut.writeBoolean(info.isDroppable());
+        looseMarshalObjectArray(wireFormat, info.getCluster(), dataOut);
+        looseMarshalLong(wireFormat, info.getBrokerInTime(), dataOut);
+        looseMarshalLong(wireFormat, info.getBrokerOutTime(), dataOut);
+        dataOut.writeBoolean(info.isJMSXGroupFirstForConsumer());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessagePullMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/MessagePullMarshaller.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConsumerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.MessageId;
+import org.apache.activemq.openwire.commands.MessagePull;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public class MessagePullMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return MessagePull.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new MessagePull();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        MessagePull info = (MessagePull) o;
+        info.setConsumerId((ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setTimeout(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setCorrelationId(tightUnmarshalString(dataIn, bs));
+        info.setMessageId((MessageId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        MessagePull info = (MessagePull) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConsumerId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getTimeout(), bs);
+        rc += tightMarshalString1(info.getCorrelationId(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getMessageId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        MessagePull info = (MessagePull) o;
+        tightMarshalCachedObject2(wireFormat, info.getConsumerId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getTimeout(), dataOut, bs);
+        tightMarshalString2(info.getCorrelationId(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getMessageId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        MessagePull info = (MessagePull) o;
+        info.setConsumerId((ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setTimeout(looseUnmarshalLong(wireFormat, dataIn));
+        info.setCorrelationId(looseUnmarshalString(dataIn));
+        info.setMessageId((MessageId) looseUnmarsalNestedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        MessagePull info = (MessagePull) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConsumerId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalLong(wireFormat, info.getTimeout(), dataOut);
+        looseMarshalString(info.getCorrelationId(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getMessageId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/NetworkBridgeFilterMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/NetworkBridgeFilterMarshaller.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.NetworkBridgeFilter;
+
+public class NetworkBridgeFilterMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return NetworkBridgeFilter.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new NetworkBridgeFilter();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        NetworkBridgeFilter info = (NetworkBridgeFilter) o;
+        info.setNetworkBrokerId((BrokerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setMessageTTL(dataIn.readInt());
+        info.setConsumerTTL(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        NetworkBridgeFilter info = (NetworkBridgeFilter) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getNetworkBrokerId(), bs);
+
+        return rc + 8;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        NetworkBridgeFilter info = (NetworkBridgeFilter) o;
+        tightMarshalCachedObject2(wireFormat, info.getNetworkBrokerId(), dataOut, bs);
+        dataOut.writeInt(info.getMessageTTL());
+        dataOut.writeInt(info.getConsumerTTL());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        NetworkBridgeFilter info = (NetworkBridgeFilter) o;
+        info.setNetworkBrokerId((BrokerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setMessageTTL(dataIn.readInt());
+        info.setConsumerTTL(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        NetworkBridgeFilter info = (NetworkBridgeFilter) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getNetworkBrokerId(), dataOut);
+        dataOut.writeInt(info.getMessageTTL());
+        dataOut.writeInt(info.getConsumerTTL());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireBlobMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireBlobMessageMarshaller.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireBlobMessage;
+
+public class OpenWireBlobMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireBlobMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireBlobMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        OpenWireBlobMessage info = (OpenWireBlobMessage) o;
+        info.setRemoteBlobUrl(tightUnmarshalString(dataIn, bs));
+        info.setMimeType(tightUnmarshalString(dataIn, bs));
+        info.setDeletedByBroker(bs.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        OpenWireBlobMessage info = (OpenWireBlobMessage) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getRemoteBlobUrl(), bs);
+        rc += tightMarshalString1(info.getMimeType(), bs);
+        bs.writeBoolean(info.isDeletedByBroker());
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        OpenWireBlobMessage info = (OpenWireBlobMessage) o;
+        tightMarshalString2(info.getRemoteBlobUrl(), dataOut, bs);
+        tightMarshalString2(info.getMimeType(), dataOut, bs);
+        bs.readBoolean();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        OpenWireBlobMessage info = (OpenWireBlobMessage) o;
+        info.setRemoteBlobUrl(looseUnmarshalString(dataIn));
+        info.setMimeType(looseUnmarshalString(dataIn));
+        info.setDeletedByBroker(dataIn.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        OpenWireBlobMessage info = (OpenWireBlobMessage) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getRemoteBlobUrl(), dataOut);
+        looseMarshalString(info.getMimeType(), dataOut);
+        dataOut.writeBoolean(info.isDeletedByBroker());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireBytesMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireBytesMessageMarshaller.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireBytesMessage;
+
+public class OpenWireBytesMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireBytesMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireBytesMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireDestinationMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireDestinationMarshaller.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+
+public abstract class OpenWireDestinationMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        OpenWireDestination info = (OpenWireDestination) o;
+        info.setPhysicalName(tightUnmarshalString(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        OpenWireDestination info = (OpenWireDestination) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getPhysicalName(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        OpenWireDestination info = (OpenWireDestination) o;
+        tightMarshalString2(info.getPhysicalName(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        OpenWireDestination info = (OpenWireDestination) o;
+        info.setPhysicalName(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        OpenWireDestination info = (OpenWireDestination) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getPhysicalName(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireMapMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireMapMessageMarshaller.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireMapMessage;
+
+public class OpenWireMapMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireMapMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireMapMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireMessageMarshaller.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireMessage;
+
+public class OpenWireMessageMarshaller extends MessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireObjectMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireObjectMessageMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireObjectMessage;
+
+public class OpenWireObjectMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireObjectMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireObjectMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireQueueMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireQueueMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireQueue;
+
+public class OpenWireQueueMarshaller extends OpenWireDestinationMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireQueue.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireQueue();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireStreamMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireStreamMessageMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireStreamMessage;
+
+public class OpenWireStreamMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireStreamMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireStreamMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempDestinationMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempDestinationMarshaller.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+
+public abstract class OpenWireTempDestinationMarshaller extends OpenWireDestinationMarshaller {
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempQueueMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempQueueMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireTempQueue;
+
+public class OpenWireTempQueueMarshaller extends OpenWireTempDestinationMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireTempQueue.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireTempQueue();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempTopicMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTempTopicMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireTempTopic;
+
+public class OpenWireTempTopicMarshaller extends OpenWireTempDestinationMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireTempTopic.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireTempTopic();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTextMessageMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTextMessageMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireTextMessage;
+
+public class OpenWireTextMessageMarshaller extends OpenWireMessageMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireTextMessage.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireTextMessage();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTopicMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/OpenWireTopicMarshaller.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireTopic;
+
+public class OpenWireTopicMarshaller extends OpenWireDestinationMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return OpenWireTopic.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new OpenWireTopic();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/PartialCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/PartialCommandMarshaller.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.PartialCommand;
+
+public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return PartialCommand.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new PartialCommand();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        PartialCommand info = (PartialCommand) o;
+        info.setCommandId(dataIn.readInt());
+        info.setData(tightUnmarshalByteArray(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        PartialCommand info = (PartialCommand) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalByteArray1(info.getData(), bs);
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        PartialCommand info = (PartialCommand) o;
+        dataOut.writeInt(info.getCommandId());
+        tightMarshalByteArray2(info.getData(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        PartialCommand info = (PartialCommand) o;
+        info.setCommandId(dataIn.readInt());
+        info.setData(looseUnmarshalByteArray(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        PartialCommand info = (PartialCommand) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getCommandId());
+        looseMarshalByteArray(wireFormat, info.getData(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerAckMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerAckMarshaller.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.ProducerAck;
+import org.apache.activemq.openwire.commands.ProducerId;
+
+public class ProducerAckMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ProducerAck.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ProducerAck();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ProducerAck info = (ProducerAck) o;
+        info.setProducerId((ProducerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setSize(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ProducerAck info = (ProducerAck) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getProducerId(), bs);
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ProducerAck info = (ProducerAck) o;
+        tightMarshalNestedObject2(wireFormat, info.getProducerId(), dataOut, bs);
+        dataOut.writeInt(info.getSize());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ProducerAck info = (ProducerAck) o;
+        info.setProducerId((ProducerId) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setSize(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ProducerAck info = (ProducerAck) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalNestedObject(wireFormat, info.getProducerId(), dataOut);
+        dataOut.writeInt(info.getSize());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerIdMarshaller.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.ProducerId;
+
+public class ProducerIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ProducerId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ProducerId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ProducerId info = (ProducerId) o;
+        info.setConnectionId(tightUnmarshalString(dataIn, bs));
+        info.setValue(tightUnmarshalLong(wireFormat, dataIn, bs));
+        info.setSessionId(tightUnmarshalLong(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ProducerId info = (ProducerId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getConnectionId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getValue(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getSessionId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ProducerId info = (ProducerId) o;
+        tightMarshalString2(info.getConnectionId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getValue(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getSessionId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ProducerId info = (ProducerId) o;
+        info.setConnectionId(looseUnmarshalString(dataIn));
+        info.setValue(looseUnmarshalLong(wireFormat, dataIn));
+        info.setSessionId(looseUnmarshalLong(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ProducerId info = (ProducerId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getConnectionId(), dataOut);
+        looseMarshalLong(wireFormat, info.getValue(), dataOut);
+        looseMarshalLong(wireFormat, info.getSessionId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ProducerInfoMarshaller.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.BrokerId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+import org.apache.activemq.openwire.commands.ProducerId;
+import org.apache.activemq.openwire.commands.ProducerInfo;
+
+public class ProducerInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ProducerInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ProducerInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ProducerInfo info = (ProducerInfo) o;
+        info.setProducerId((ProducerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+
+        if (bs.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) tightUnmarsalNestedObject(wireFormat, dataIn, bs);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setDispatchAsync(bs.readBoolean());
+        info.setWindowSize(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        ProducerInfo info = (ProducerInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getProducerId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalObjectArray1(wireFormat, info.getBrokerPath(), bs);
+        bs.writeBoolean(info.isDispatchAsync());
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ProducerInfo info = (ProducerInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getProducerId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalObjectArray2(wireFormat, info.getBrokerPath(), dataOut, bs);
+        bs.readBoolean();
+        dataOut.writeInt(info.getWindowSize());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ProducerInfo info = (ProducerInfo) o;
+        info.setProducerId((ProducerId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+
+        if (dataIn.readBoolean()) {
+            short size = dataIn.readShort();
+            BrokerId value[] = new BrokerId[size];
+            for (int i = 0; i < size; i++) {
+                value[i] = (BrokerId) looseUnmarsalNestedObject(wireFormat, dataIn);
+            }
+            info.setBrokerPath(value);
+        } else {
+            info.setBrokerPath(null);
+        }
+        info.setDispatchAsync(dataIn.readBoolean());
+        info.setWindowSize(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ProducerInfo info = (ProducerInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getProducerId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalObjectArray(wireFormat, info.getBrokerPath(), dataOut);
+        dataOut.writeBoolean(info.isDispatchAsync());
+        dataOut.writeInt(info.getWindowSize());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/RemoveInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/RemoveInfoMarshaller.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.RemoveInfo;
+
+public class RemoveInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return RemoveInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new RemoveInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        RemoveInfo info = (RemoveInfo) o;
+        info.setObjectId(tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setLastDeliveredSequenceId(tightUnmarshalLong(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        RemoveInfo info = (RemoveInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getObjectId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getLastDeliveredSequenceId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        RemoveInfo info = (RemoveInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getObjectId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getLastDeliveredSequenceId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        RemoveInfo info = (RemoveInfo) o;
+        info.setObjectId(looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setLastDeliveredSequenceId(looseUnmarshalLong(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        RemoveInfo info = (RemoveInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getObjectId(), dataOut);
+        looseMarshalLong(wireFormat, info.getLastDeliveredSequenceId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/RemoveSubscriptionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/RemoveSubscriptionInfoMarshaller.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.RemoveSubscriptionInfo;
+
+public class RemoveSubscriptionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return RemoveSubscriptionInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new RemoveSubscriptionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        RemoveSubscriptionInfo info = (RemoveSubscriptionInfo) o;
+        info.setConnectionId((ConnectionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setSubcriptionName(tightUnmarshalString(dataIn, bs));
+        info.setClientId(tightUnmarshalString(dataIn, bs));
+
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        RemoveSubscriptionInfo info = (RemoveSubscriptionInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConnectionId(), bs);
+        rc += tightMarshalString1(info.getSubcriptionName(), bs);
+        rc += tightMarshalString1(info.getClientId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        RemoveSubscriptionInfo info = (RemoveSubscriptionInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+        tightMarshalString2(info.getSubcriptionName(), dataOut, bs);
+        tightMarshalString2(info.getClientId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        RemoveSubscriptionInfo info = (RemoveSubscriptionInfo) o;
+        info.setConnectionId((ConnectionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setSubcriptionName(looseUnmarshalString(dataIn));
+        info.setClientId(looseUnmarshalString(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        RemoveSubscriptionInfo info = (RemoveSubscriptionInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConnectionId(), dataOut);
+        looseMarshalString(info.getSubcriptionName(), dataOut);
+        looseMarshalString(info.getClientId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ReplayCommandMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ReplayCommandMarshaller.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.ReplayCommand;
+
+public class ReplayCommandMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ReplayCommand.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ReplayCommand();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        ReplayCommand info = (ReplayCommand) o;
+        info.setFirstNakNumber(dataIn.readInt());
+        info.setLastNakNumber(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 8;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        ReplayCommand info = (ReplayCommand) o;
+        dataOut.writeInt(info.getFirstNakNumber());
+        dataOut.writeInt(info.getLastNakNumber());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        ReplayCommand info = (ReplayCommand) o;
+        info.setFirstNakNumber(dataIn.readInt());
+        info.setLastNakNumber(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        ReplayCommand info = (ReplayCommand) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getFirstNakNumber());
+        dataOut.writeInt(info.getLastNakNumber());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ResponseMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ResponseMarshaller.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.Response;
+
+public class ResponseMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return Response.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new Response();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        Response info = (Response) o;
+        info.setCorrelationId(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        Response info = (Response) o;
+        dataOut.writeInt(info.getCorrelationId());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        Response info = (Response) o;
+        info.setCorrelationId(dataIn.readInt());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        Response info = (Response) o;
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getCorrelationId());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SessionIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SessionIdMarshaller.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.SessionId;
+
+public class SessionIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return SessionId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new SessionId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        SessionId info = (SessionId) o;
+        info.setConnectionId(tightUnmarshalString(dataIn, bs));
+        info.setValue(tightUnmarshalLong(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        SessionId info = (SessionId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getConnectionId(), bs);
+        rc += tightMarshalLong1(wireFormat, info.getValue(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        SessionId info = (SessionId) o;
+        tightMarshalString2(info.getConnectionId(), dataOut, bs);
+        tightMarshalLong2(wireFormat, info.getValue(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        SessionId info = (SessionId) o;
+        info.setConnectionId(looseUnmarshalString(dataIn));
+        info.setValue(looseUnmarshalLong(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        SessionId info = (SessionId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getConnectionId(), dataOut);
+        looseMarshalLong(wireFormat, info.getValue(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SessionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SessionInfoMarshaller.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.SessionId;
+import org.apache.activemq.openwire.commands.SessionInfo;
+
+public class SessionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return SessionInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new SessionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        SessionInfo info = (SessionInfo) o;
+        info.setSessionId((SessionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        SessionInfo info = (SessionInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getSessionId(), bs);
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        SessionInfo info = (SessionInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getSessionId(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        SessionInfo info = (SessionInfo) o;
+        info.setSessionId((SessionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        SessionInfo info = (SessionInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getSessionId(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ShutdownInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/ShutdownInfoMarshaller.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.ShutdownInfo;
+
+public class ShutdownInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return ShutdownInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new ShutdownInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SubscriptionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/SubscriptionInfoMarshaller.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.OpenWireDestination;
+import org.apache.activemq.openwire.commands.SubscriptionInfo;
+
+public class SubscriptionInfoMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return SubscriptionInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new SubscriptionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        SubscriptionInfo info = (SubscriptionInfo) o;
+        info.setClientId(tightUnmarshalString(dataIn, bs));
+        info.setDestination((OpenWireDestination) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setSelector(tightUnmarshalString(dataIn, bs));
+        info.setSubcriptionName(tightUnmarshalString(dataIn, bs));
+        info.setSubscribedDestination((OpenWireDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
+        info.setNoLocal(bs.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        SubscriptionInfo info = (SubscriptionInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalString1(info.getClientId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getDestination(), bs);
+        rc += tightMarshalString1(info.getSelector(), bs);
+        rc += tightMarshalString1(info.getSubcriptionName(), bs);
+        rc += tightMarshalNestedObject1(wireFormat, info.getSubscribedDestination(), bs);
+        bs.writeBoolean(info.isNoLocal());
+
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        SubscriptionInfo info = (SubscriptionInfo) o;
+        tightMarshalString2(info.getClientId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getDestination(), dataOut, bs);
+        tightMarshalString2(info.getSelector(), dataOut, bs);
+        tightMarshalString2(info.getSubcriptionName(), dataOut, bs);
+        tightMarshalNestedObject2(wireFormat, info.getSubscribedDestination(), dataOut, bs);
+        bs.readBoolean();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        SubscriptionInfo info = (SubscriptionInfo) o;
+        info.setClientId(looseUnmarshalString(dataIn));
+        info.setDestination((OpenWireDestination) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setSelector(looseUnmarshalString(dataIn));
+        info.setSubcriptionName(looseUnmarshalString(dataIn));
+        info.setSubscribedDestination((OpenWireDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
+        info.setNoLocal(dataIn.readBoolean());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        SubscriptionInfo info = (SubscriptionInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalString(info.getClientId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getDestination(), dataOut);
+        looseMarshalString(info.getSelector(), dataOut);
+        looseMarshalString(info.getSubcriptionName(), dataOut);
+        looseMarshalNestedObject(wireFormat, info.getSubscribedDestination(), dataOut);
+        dataOut.writeBoolean(info.isNoLocal());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/TransactionIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/TransactionIdMarshaller.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+
+public abstract class TransactionIdMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        return rc + 0;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        super.looseMarshal(wireFormat, o, dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/TransactionInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/TransactionInfoMarshaller.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.ConnectionId;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.TransactionId;
+import org.apache.activemq.openwire.commands.TransactionInfo;
+
+public class TransactionInfoMarshaller extends BaseCommandMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return TransactionInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new TransactionInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        TransactionInfo info = (TransactionInfo) o;
+        info.setConnectionId((ConnectionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setTransactionId((TransactionId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
+        info.setType(dataIn.readByte());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        TransactionInfo info = (TransactionInfo) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getConnectionId(), bs);
+        rc += tightMarshalCachedObject1(wireFormat, info.getTransactionId(), bs);
+
+        return rc + 1;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        TransactionInfo info = (TransactionInfo) o;
+        tightMarshalCachedObject2(wireFormat, info.getConnectionId(), dataOut, bs);
+        tightMarshalCachedObject2(wireFormat, info.getTransactionId(), dataOut, bs);
+        dataOut.writeByte(info.getType());
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        TransactionInfo info = (TransactionInfo) o;
+        info.setConnectionId((ConnectionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setTransactionId((TransactionId) looseUnmarsalCachedObject(wireFormat, dataIn));
+        info.setType(dataIn.readByte());
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        TransactionInfo info = (TransactionInfo) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalCachedObject(wireFormat, info.getConnectionId(), dataOut);
+        looseMarshalCachedObject(wireFormat, info.getTransactionId(), dataOut);
+        dataOut.writeByte(info.getType());
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/WireFormatInfoMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/WireFormatInfoMarshaller.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BaseDataStreamMarshaller;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.WireFormatInfo;
+
+public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return WireFormatInfo.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new WireFormatInfo();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        WireFormatInfo info = (WireFormatInfo) o;
+
+        info.beforeUnmarshall(wireFormat);
+
+        info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
+        info.setVersion(dataIn.readInt());
+        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+
+        info.afterUnmarshall(wireFormat);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        WireFormatInfo info = (WireFormatInfo) o;
+
+        info.beforeMarshall(wireFormat);
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalConstByteArray1(info.getMagic(), bs, 8);
+        rc += tightMarshalByteSequence1(info.getMarshalledProperties(), bs);
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        WireFormatInfo info = (WireFormatInfo) o;
+        tightMarshalConstByteArray2(info.getMagic(), dataOut, bs, 8);
+        dataOut.writeInt(info.getVersion());
+        tightMarshalByteSequence2(info.getMarshalledProperties(), dataOut, bs);
+
+        info.afterMarshall(wireFormat);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        WireFormatInfo info = (WireFormatInfo) o;
+
+        info.beforeUnmarshall(wireFormat);
+
+        info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
+        info.setVersion(dataIn.readInt());
+        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+
+        info.afterUnmarshall(wireFormat);
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        WireFormatInfo info = (WireFormatInfo) o;
+
+        info.beforeMarshall(wireFormat);
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        looseMarshalConstByteArray(wireFormat, info.getMagic(), dataOut, 8);
+        dataOut.writeInt(info.getVersion());
+        looseMarshalByteSequence(wireFormat, info.getMarshalledProperties(), dataOut);
+    }
+}

--- a/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/XATransactionIdMarshaller.java
+++ b/openwire-legacy/src/main/java/org/apache/activemq/openwire/codec/v12/XATransactionIdMarshaller.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.codec.v12;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import org.apache.activemq.openwire.codec.BooleanStream;
+import org.apache.activemq.openwire.codec.OpenWireFormat;
+import org.apache.activemq.openwire.commands.DataStructure;
+import org.apache.activemq.openwire.commands.XATransactionId;
+
+public class XATransactionIdMarshaller extends TransactionIdMarshaller {
+
+    /**
+     * Return the type of Data Structure we marshal
+     *
+     * @return short representation of the type data structure
+     */
+    @Override
+    public byte getDataStructureType() {
+        return XATransactionId.DATA_STRUCTURE_TYPE;
+    }
+
+    /**
+     * @return a new object instance
+     */
+    @Override
+    public DataStructure createObject() {
+        return new XATransactionId();
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void tightUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn, BooleanStream bs) throws IOException {
+        super.tightUnmarshal(wireFormat, o, dataIn, bs);
+
+        XATransactionId info = (XATransactionId) o;
+        info.setFormatId(dataIn.readInt());
+        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public int tightMarshal1(OpenWireFormat wireFormat, Object o, BooleanStream bs) throws IOException {
+        XATransactionId info = (XATransactionId) o;
+
+        int rc = super.tightMarshal1(wireFormat, o, bs);
+        rc += tightMarshalByteArray1(info.getGlobalTransactionId(), bs);
+        rc += tightMarshalByteArray1(info.getBranchQualifier(), bs);
+
+        return rc + 4;
+    }
+
+    /**
+     * Write a object instance to data output stream
+     *
+     * @param o
+     *        the instance to be marshaled
+     * @param dataOut
+     *        the output stream
+     * @throws IOException
+     *         thrown if an error occurs
+     */
+    @Override
+    public void tightMarshal2(OpenWireFormat wireFormat, Object o, DataOutput dataOut, BooleanStream bs) throws IOException {
+        super.tightMarshal2(wireFormat, o, dataOut, bs);
+
+        XATransactionId info = (XATransactionId) o;
+        dataOut.writeInt(info.getFormatId());
+        tightMarshalByteArray2(info.getGlobalTransactionId(), dataOut, bs);
+        tightMarshalByteArray2(info.getBranchQualifier(), dataOut, bs);
+    }
+
+    /**
+     * Un-marshal an object instance from the data input stream
+     *
+     * @param o
+     *        the object to un-marshal
+     * @param dataIn
+     *        the data input stream to build the object from
+     * @throws IOException
+     */
+    @Override
+    public void looseUnmarshal(OpenWireFormat wireFormat, Object o, DataInput dataIn) throws IOException {
+        super.looseUnmarshal(wireFormat, o, dataIn);
+
+        XATransactionId info = (XATransactionId) o;
+        info.setFormatId(dataIn.readInt());
+        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+    }
+
+    /**
+     * Write the booleans that this object uses to a BooleanStream
+     */
+    @Override
+    public void looseMarshal(OpenWireFormat wireFormat, Object o, DataOutput dataOut) throws IOException {
+        XATransactionId info = (XATransactionId) o;
+
+        super.looseMarshal(wireFormat, o, dataOut);
+        dataOut.writeInt(info.getFormatId());
+        looseMarshalByteArray(wireFormat, info.getGlobalTransactionId(), dataOut);
+        looseMarshalByteArray(wireFormat, info.getBranchQualifier(), dataOut);
+    }
+}


### PR DESCRIPTION
This adds support for OpenWire v12 which includes the BrokerSubsriptionInfo command that was added. Legacy marshallers were added as well as interop tests for the new command.